### PR TITLE
Allow reader/writer subclasses to provide the underlying file operations

### DIFF
--- a/src/main/java/cuchaz/enigma/mapping/MappingsEnigmaWriter.java
+++ b/src/main/java/cuchaz/enigma/mapping/MappingsEnigmaWriter.java
@@ -85,7 +85,7 @@ public class MappingsEnigmaWriter {
 		}
 	}
 
-	private void write(PrintWriter out, ClassMapping classMapping, int depth) throws IOException {
+	protected void write(PrintWriter out, ClassMapping classMapping, int depth) throws IOException {
 		if (classMapping.getDeobfName() == null) {
 			out.format("%sCLASS %s%s\n", getIndent(depth), classMapping.getObfFullName(),
 					classMapping.getModifier() == Mappings.EntryModifier.UNCHANGED ? "" : classMapping.getModifier().getFormattedName());
@@ -134,7 +134,7 @@ public class MappingsEnigmaWriter {
 		out.format("%sARG %d %s\n", getIndent(depth), localVariableMapping.getIndex(), localVariableMapping.getName());
 	}
 
-	private <T extends Comparable<T>> List<T> sorted(Iterable<T> classes) {
+	protected <T extends Comparable<T>> List<T> sorted(Iterable<T> classes) {
 		List<T> out = new ArrayList<>();
 		for (T t : classes) {
 			out.add(t);

--- a/src/main/java/cuchaz/enigma/throwables/MappingParseException.java
+++ b/src/main/java/cuchaz/enigma/throwables/MappingParseException.java
@@ -12,6 +12,7 @@
 package cuchaz.enigma.throwables;
 
 import java.io.File;
+import java.util.function.Supplier;
 
 public class MappingParseException extends Exception {
 
@@ -23,6 +24,12 @@ public class MappingParseException extends Exception {
 		this.line = line;
 		this.message = message;
 		filePath = file.getAbsolutePath();
+	}
+
+	public MappingParseException(Supplier<String> filenameProvider, int line, String message) {
+		this.line = line;
+		this.message = message;
+		filePath = filenameProvider.get();
 	}
 
 	@Override


### PR DESCRIPTION
Should allow subclasses to implement the file saving/reading while still using the lib as the definite source for the format parsing/serialising

- Opened as PR as I no haz access
- Opened against `asm` just because that's what we use, should be cherrypickable though