### PR TITLE
Speedy getsources + sig fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,6 +150,7 @@ flycheck_*.el
 
 # IntelliJ
 /out/
+.idea
 
 # mpeltonen/sbt-idea plugin
 .idea_modules/

--- a/src/main/java/cuchaz/enigma/CachingClasspathTypeLoader.java
+++ b/src/main/java/cuchaz/enigma/CachingClasspathTypeLoader.java
@@ -1,0 +1,20 @@
+package cuchaz.enigma;
+
+import com.strobel.assembler.metadata.Buffer;
+import com.strobel.assembler.metadata.ClasspathTypeLoader;
+import com.strobel.assembler.metadata.ITypeLoader;
+
+/**
+ * Caching version of {@link ClasspathTypeLoader}
+ */
+class CachingClasspathTypeLoader extends CachingTypeLoader {
+	private final ITypeLoader classpathLoader = new ClasspathTypeLoader();
+
+	protected byte[] doLoad(String className) {
+		Buffer parentBuf = new Buffer();
+		if (classpathLoader.tryLoadType(className, parentBuf)) {
+			return parentBuf.array();
+		}
+		return EMPTY_ARRAY;//need to return *something* as null means no store
+	}
+}

--- a/src/main/java/cuchaz/enigma/CachingTypeLoader.java
+++ b/src/main/java/cuchaz/enigma/CachingTypeLoader.java
@@ -1,0 +1,38 @@
+package cuchaz.enigma;
+
+import com.google.common.collect.Maps;
+import com.strobel.assembler.metadata.Buffer;
+import com.strobel.assembler.metadata.ITypeLoader;
+
+import java.util.Map;
+
+/**
+ * Common cache functions
+ */
+public abstract class CachingTypeLoader implements ITypeLoader {
+	protected static final byte[] EMPTY_ARRAY = {};
+
+	private final Map<String, byte[]> cache = Maps.newHashMap();
+
+	protected abstract byte[] doLoad(String className);
+
+	@Override
+	public boolean tryLoadType(String className, Buffer out) {
+
+		// check the cache
+		byte[] data = this.cache.computeIfAbsent(className, this::doLoad);
+
+		if (data == EMPTY_ARRAY) {
+			return false;
+		}
+
+		out.reset(data.length);
+		System.arraycopy(data, 0, out.array(), out.position(), data.length);
+		out.position(0);
+		return true;
+	}
+
+	public void clearCache() {
+		this.cache.clear();
+	}
+}

--- a/src/main/java/cuchaz/enigma/Deobfuscator.java
+++ b/src/main/java/cuchaz/enigma/Deobfuscator.java
@@ -15,7 +15,6 @@ import com.google.common.base.Stopwatch;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.strobel.assembler.metadata.Buffer;
 import com.strobel.assembler.metadata.MetadataSystem;
 import com.strobel.assembler.metadata.TypeDefinition;
 import com.strobel.assembler.metadata.TypeReference;
@@ -667,31 +666,4 @@ public class Deobfuscator {
 		String transform(ClassNode node, ClassWriter writer);
 	}
 
-	private class SynchronizedTypeLoader implements ITranslatingTypeLoader {
-		private final TranslatingTypeLoader delegate;
-
-		private SynchronizedTypeLoader(TranslatingTypeLoader delegate) {
-			this.delegate = delegate;
-		}
-
-		@Override
-		public List<String> getClassNamesToTry(String className) {
-			return delegate.getClassNamesToTry(className);
-		}
-
-		@Override
-		public List<String> getClassNamesToTry(ClassEntry obfClassEntry) {
-			return delegate.getClassNamesToTry(obfClassEntry);
-		}
-
-		@Override
-		public String transformInto(ClassNode node, ClassWriter writer) {
-			return delegate.transformInto(node, writer);
-		}
-
-		@Override
-		public synchronized boolean tryLoadType(String internalName, Buffer buffer) {
-			return delegate.tryLoadType(internalName, buffer);
-		}
-	}
 }

--- a/src/main/java/cuchaz/enigma/ITranslatingTypeLoader.java
+++ b/src/main/java/cuchaz/enigma/ITranslatingTypeLoader.java
@@ -1,0 +1,19 @@
+package cuchaz.enigma;
+
+import com.strobel.assembler.metadata.ITypeLoader;
+import cuchaz.enigma.mapping.entry.ClassEntry;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.tree.ClassNode;
+
+import java.util.List;
+
+/**
+ * For delegation of TranslatingTypeLoader without needing the subclass the whole thing
+ */
+public interface ITranslatingTypeLoader extends ITypeLoader {
+	List<String> getClassNamesToTry(String className);
+
+	List<String> getClassNamesToTry(ClassEntry obfClassEntry);
+
+	String transformInto(ClassNode node, ClassWriter writer);
+}

--- a/src/main/java/cuchaz/enigma/SynchronizedTypeLoader.java
+++ b/src/main/java/cuchaz/enigma/SynchronizedTypeLoader.java
@@ -1,0 +1,39 @@
+package cuchaz.enigma;
+
+import com.strobel.assembler.metadata.Buffer;
+import cuchaz.enigma.mapping.entry.ClassEntry;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.tree.ClassNode;
+
+import java.util.List;
+
+/**
+ * Typeloader with synchronized tryLoadType method
+ */
+public class SynchronizedTypeLoader implements ITranslatingTypeLoader {
+	private final TranslatingTypeLoader delegate;
+
+	SynchronizedTypeLoader(TranslatingTypeLoader delegate) {
+		this.delegate = delegate;
+	}
+
+	@Override
+	public List<String> getClassNamesToTry(String className) {
+		return delegate.getClassNamesToTry(className);
+	}
+
+	@Override
+	public List<String> getClassNamesToTry(ClassEntry obfClassEntry) {
+		return delegate.getClassNamesToTry(obfClassEntry);
+	}
+
+	@Override
+	public String transformInto(ClassNode node, ClassWriter writer) {
+		return delegate.transformInto(node, writer);
+	}
+
+	@Override
+	public synchronized boolean tryLoadType(String internalName, Buffer buffer) {
+		return delegate.tryLoadType(internalName, buffer);
+	}
+}


### PR DESCRIPTION
Speeds up the deobf for a jar with caching, also fixes the signature remapper for odd inner classes with a parent with generics